### PR TITLE
Add .NET 8 REST API with Swagger/OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
 # ThePit
 
-A .NET project.
+A .NET REST API with Swagger/OpenAPI documentation.
 
 ## Getting Started
 
-*Coming soon*
+### Prerequisites
+- .NET 8.0 SDK
+
+### Running the API
+
+```bash
+cd src/ThePit.Api
+dotnet run
+```
+
+The API will be available at `https://localhost:5001` (or `http://localhost:5000`).
+
+### Swagger UI
+
+When running in Development mode, Swagger UI is available at the root URL (`/`).
+
+The OpenAPI specification is available at `/swagger/v1/swagger.json`.
+
+## API Endpoints
+
+- `GET /api/weatherforecast` - Get weather forecast for the next 5 days
 
 ## License
 

--- a/ThePit.sln
+++ b/ThePit.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThePit.Api", "src\ThePit.Api\ThePit.Api.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/ThePit.Api/Controllers/WeatherForecastController.cs
+++ b/src/ThePit.Api/Controllers/WeatherForecastController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ThePit.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    /// <summary>
+    /// Gets weather forecast for the next 5 days
+    /// </summary>
+    /// <returns>A list of weather forecasts</returns>
+    [HttpGet(Name = "GetWeatherForecast")]
+    [ProducesResponseType(typeof(IEnumerable<WeatherForecast>), StatusCodes.Status200OK)]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}
+
+public class WeatherForecast
+{
+    public DateOnly Date { get; set; }
+    public int TemperatureC { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public string? Summary { get; set; }
+}

--- a/src/ThePit.Api/Program.cs
+++ b/src/ThePit.Api/Program.cs
@@ -1,0 +1,33 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    {
+        Version = "v1",
+        Title = "ThePit API",
+        Description = "A .NET REST API for ThePit"
+    });
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/swagger/v1/swagger.json", "ThePit API v1");
+        options.RoutePrefix = string.Empty; // Serve Swagger UI at root
+    });
+}
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/src/ThePit.Api/ThePit.Api.csproj
+++ b/src/ThePit.Api/ThePit.Api.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/ThePit.Api/appsettings.Development.json
+++ b/src/ThePit.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/ThePit.Api/appsettings.json
+++ b/src/ThePit.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- Creates a .NET 8 Web API project with Swagger/OpenAPI documentation
- Adds Swashbuckle.AspNetCore package for OpenAPI support
- Configures Swagger UI at root URL (`/`) in development mode
- Includes sample WeatherForecast controller demonstrating API documentation

## Test plan
- [ ] Build the project: `cd src/ThePit.Api && dotnet build`
- [ ] Run the API: `dotnet run`
- [ ] Access Swagger UI at root URL
- [ ] Verify OpenAPI spec at `/swagger/v1/swagger.json`
- [ ] Test WeatherForecast endpoint via Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)