### PR TITLE
Fix CI/CD status badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThePit
 
-[![.NET Core Desktop](https://github.com/JasonEAshworth/ThePit/actions/workflows/dotnet-desktop.yml/badge.svg)](https://github.com/JasonEAshworth/ThePit/actions/workflows/dotnet-desktop.yml)
+[![.NET](https://github.com/JasonEAshworth/ThePit/actions/workflows/dotnet.yml/badge.svg)](https://github.com/JasonEAshworth/ThePit/actions/workflows/dotnet.yml)
 [![SvelteKit Frontend](https://github.com/JasonEAshworth/ThePit/actions/workflows/sveltekit-frontend.yml/badge.svg)](https://github.com/JasonEAshworth/ThePit/actions/workflows/sveltekit-frontend.yml)
 
 A .NET 8 REST API with a SvelteKit frontend for invoice and payment management.


### PR DESCRIPTION
## Summary
- Fix .NET workflow badge to point to correct workflow file (`dotnet.yml` instead of non-existent `dotnet-desktop.yml`)
- SvelteKit Frontend badge already correct

## Test plan
- [ ] Verify .NET badge renders correctly and links to workflow
- [ ] Verify SvelteKit badge renders correctly and links to workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)